### PR TITLE
Add Makefile.PL and allow banned IP's to be derived from a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@ obj/
 .clangd
 .depend
 http/f/*
+blib/
+pm_to_blib
+Makefile
+Makefile.old
+MANIFEST*
+!MANIFEST.SKIP
+META.*/
+MYMETA.*
+pm_to_blib

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ MANIFEST*
 META.*/
 MYMETA.*
 pm_to_blib
+sakisafe.log
+f/

--- a/http/Makefile.PL
+++ b/http/Makefile.PL
@@ -1,3 +1,5 @@
+use v5.36;
+
 use ExtUtils::MakeMaker;
 
 WriteMakefile(
@@ -7,7 +9,9 @@ WriteMakefile(
         "List::MoreUtils" => 0,
         "Term::ANSIColor" => 0,
         "MIME::Types" => 0,
-        "Path::Tiny" => 0
+        "Path::Tiny" => 0,
+        "Mojolicious::Plugin::RenderFile" => 0,
+        "Mojolicious::Routes::Pattern" => 0
     },
     EXE_FILES => ['sakisafe.pl']
 );

--- a/http/Makefile.PL
+++ b/http/Makefile.PL
@@ -1,0 +1,13 @@
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME => 'sakisafe',
+    PREREQ_PM => {
+        "Mojolicious" => 0,
+        "List::MoreUtils" => 0,
+        "Term::ANSIColor" => 0,
+        "MIME::Types" => 0,
+        "Path::Tiny" => 0
+    },
+    EXE_FILES => ['sakisafe.pl']
+);

--- a/http/sakisafe.pl
+++ b/http/sakisafe.pl
@@ -22,7 +22,7 @@ pledge("stdio cpath rpath wpath inet flock fattr") if $^O eq "openbsd";
 
 my $MAX_SIZE = 1024 * 1024 * 100;
 
-my @BANNED = path('banned.txt')->slurp_utf8 || qw(); # Add banned IP addresses here
+my @BANNED = eval { path('banned.txt')->slurp_utf8 } or qw(); # Add banned IP addresses here
 my $dirname;
 my $link;
 
@@ -119,8 +119,8 @@ get '/f/:dir/#name' => sub ($c) {
 				 content_disposition => 'inline'
 				);
 
-}
-;
+};
+
 app->max_request_size( 1024 * 1024 * 100 );
 
 post '/upload' => sub ($c) { handle_file($c) };

--- a/http/sakisafe.pl
+++ b/http/sakisafe.pl
@@ -9,21 +9,20 @@ use Carp;
 use Term::ANSIColor;
 use English;
 use MIME::Types;
+use Path::Tiny;
 use warnings;
 use experimental 'signatures';
 use feature 'say';
 plugin 'RenderFile';
 
 # OpenBSD promises.
-my $openbsd = 0;
-$openbsd = 1 if $^O eq "openbsd";
-pledge("stdio cpath rpath wpath inet flock fattr") if $openbsd;
+pledge("stdio cpath rpath wpath inet flock fattr") if $^O eq "openbsd";
 
 # 100 MBs
 
 my $MAX_SIZE = 1024 * 1024 * 100;
 
-my @BANNED = qw();			  # Add banned IP addresses here
+my @BANNED = path('banned.txt')->slurp_utf8 || qw(); # Add banned IP addresses here
 my $dirname;
 my $link;
 
@@ -46,6 +45,7 @@ sub handle_file {
 					   status => 400
 					  );
 	}
+    
 	if ( List::MoreUtils::any { /$c->tx->remote_address/ } uniq @BANNED ) {
 		$c->render(
 				 text =>


### PR DESCRIPTION
I wanted to run this in Docker, it's much easier to do so with a `Makefile.PL`, so I added one. I also added the option to derive banned IP's from a file, since I have a pretty comprehensive list of IP's I don't want anywhere near my VPS's lol.